### PR TITLE
fix: Pin `aws-apigateway-v2` module to match required AWS provider version

### DIFF
--- a/infrastructure/modules/backend/README.md
+++ b/infrastructure/modules/backend/README.md
@@ -17,7 +17,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_websocket_api"></a> [aws\_websocket\_api](#module\_aws\_websocket\_api) | terraform-aws-modules/apigateway-v2/aws | n/a |
+| <a name="module_aws_websocket_api"></a> [aws\_websocket\_api](#module\_aws\_websocket\_api) | terraform-aws-modules/apigateway-v2/aws | ~> 5.2.1 |
 | <a name="module_lambda_trigger_connections_api"></a> [lambda\_trigger\_connections\_api](#module\_lambda\_trigger\_connections\_api) | terraform-aws-modules/lambda/aws | ~> 4.0 |
 | <a name="module_lambda_trigger_vector_search"></a> [lambda\_trigger\_vector\_search](#module\_lambda\_trigger\_vector\_search) | terraform-aws-modules/lambda/aws | ~> 4.0 |
 | <a name="module_websocket_chat_api_lambda"></a> [websocket\_chat\_api\_lambda](#module\_websocket\_chat\_api\_lambda) | terraform-aws-modules/lambda/aws | ~> 4.0 |

--- a/infrastructure/modules/backend/main.tf
+++ b/infrastructure/modules/backend/main.tf
@@ -3,7 +3,8 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 module "aws_websocket_api" {
-  source = "terraform-aws-modules/apigateway-v2/aws"
+  source  = "terraform-aws-modules/apigateway-v2/aws"
+  version = "~> 5.2.1"
 
   # API
   description = "Chatbot AWS API Websocket Gateway"


### PR DESCRIPTION
An update to the `aws-apigateway-v2` module bumped the provider version of `aws` to `v5.96`, while we are requiring `v5.76.0`. Pinning to an older version of the module resolves this issue.