### PR TITLE
Dependabot fixes + mongodb vector search update + improvement on websocket connection on UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
-        "@astrojs/react": "^3.6.2",
-        "@astrojs/tailwind": "^5.1.2",
-        "@types/react": "^18.3.11",
-        "@types/react-dom": "^18.3.0",
+        "@astrojs/react": "^3.6.3",
+        "@astrojs/tailwind": "^5.1.5",
+        "@types/react": "^18.3.21",
+        "@types/react-dom": "^18.3.7",
         "astro": "^4.16.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-icons": "^5.3.0",
-        "react-markdown": "^9.0.1",
-        "react-use-websocket": "^4.10.1",
-        "tailwindcss": "^3.4.13",
-        "typescript": "^5.6.3"
+        "react-icons": "^5.5.0",
+        "react-markdown": "^9.1.0",
+        "react-use-websocket": "^4.13.0",
+        "tailwindcss": "^3.4.17",
+        "typescript": "^5.8.3"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.15",

--- a/infrastructure/modules/backend/functions/requirements.txt
+++ b/infrastructure/modules/backend/functions/requirements.txt
@@ -2,3 +2,6 @@ boto3==1.38.18
 confluent-kafka==2.10.0
 jsonschema==4.23.0
 requests==2.32.4
+httpx>=0.28.0
+cachetools>=6.1.0
+authlib==1.6.0 

--- a/infrastructure/modules/backend/search/pom.xml
+++ b/infrastructure/modules/backend/search/pom.xml
@@ -11,7 +11,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.19.0</version>
+                <version>2.15.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -23,26 +23,26 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>5.5.0</version>
+            <version>5.0.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.confluent/kafka-json-schema-serializer -->
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-schema-serializer</artifactId>
-            <version>7.9.1-180</version>
+            <version>7.7.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.9.1</version>
+            <version>3.7.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-secretsmanager -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-secretsmanager</artifactId>
-            <version>1.12.783</version>
+            <version>1.12.778</version>
         </dependency>
 
         <dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -65,43 +65,43 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.18</version>
+            <version>1.5.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.38</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.12.2</version>
+            <version>5.10.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.0</version>
+            <version>1.20.4</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.testcontainers/kafka -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>1.21.0</version>
+            <version>1.20.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/infrastructure/modules/backend/search/pom.xml
+++ b/infrastructure/modules/backend/search/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>5.0.1</version>
+            <version>5.5.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.confluent/kafka-json-schema-serializer -->

--- a/infrastructure/modules/backend/search/pom.xml
+++ b/infrastructure/modules/backend/search/pom.xml
@@ -11,7 +11,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.15.2</version>
+                <version>2.19.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-secretsmanager</artifactId>
-            <version>1.12.778</version>
+            <version>1.12.783</version>
         </dependency>
 
         <dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -65,43 +65,43 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.18</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.34</version>
+            <version>1.18.38</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.3</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.20.4</version>
+            <version>1.21.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.testcontainers/kafka -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>1.20.4</version>
+            <version>1.21.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/infrastructure/modules/backend/search/src/main/java/io/confluent/pie/search/services/KafkaProducerSupplier.java
+++ b/infrastructure/modules/backend/search/src/main/java/io/confluent/pie/search/services/KafkaProducerSupplier.java
@@ -46,7 +46,7 @@ public class KafkaProducerSupplier implements Supplier<Producer<SearchResultsKey
                     configuration.getCcCredentials(),
                     configuration.getSrURL(),
                     configuration.getSrCredentials(),
-                    false);
+                    true); // true to enable schema registry
 
             return new KafkaProducer<>(properties);
         } catch (Throwable e) {

--- a/infrastructure/modules/backend/search/src/main/java/io/confluent/pie/search/services/impl/MongoService.java
+++ b/infrastructure/modules/backend/search/src/main/java/io/confluent/pie/search/services/impl/MongoService.java
@@ -19,7 +19,9 @@ import java.util.List;
 import static com.google.common.primitives.Doubles.asList;
 import static com.mongodb.client.model.Aggregates.project;
 import static com.mongodb.client.model.Aggregates.vectorSearch;
-import static com.mongodb.client.model.Projections.*;
+import static com.mongodb.client.model.Projections.exclude;
+import static com.mongodb.client.model.Projections.fields;
+import static com.mongodb.client.model.Projections.metaVectorSearchScore;
 import static com.mongodb.client.model.search.SearchPath.fieldPath;
 
 /**

--- a/infrastructure/modules/backend/search/src/main/java/io/confluent/pie/search/services/impl/MongoService.java
+++ b/infrastructure/modules/backend/search/src/main/java/io/confluent/pie/search/services/impl/MongoService.java
@@ -5,6 +5,7 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.search.FieldSearchPath;
+import com.mongodb.client.model.search.VectorSearchOptions;
 import io.confluent.pie.search.models.Credentials;
 import io.confluent.pie.search.models.SearchRequest;
 import io.confluent.pie.search.services.DBService;
@@ -83,12 +84,14 @@ public class MongoService implements Closeable, DBService {
         final List<Document> products = new ArrayList<>();
         final boolean hasScoreFilter = request.minScore() > 0;
 
+        final VectorSearchOptions options = VectorSearchOptions.approximateVectorSearchOptions((long) request.numberOfCandidate());
+        
         final List<Bson> pipeline = List.of(vectorSearch(
                         fieldSearchPath,
                         asList(request.embeddings()),
                         indexName,
-                        request.numberOfCandidate(),
-                        request.limit()),
+                        (long) request.limit(),
+                        options),
                 project(fields(
                         exclude(embeddingsFieldName),
                         metaVectorSearchScore("score"))));


### PR DESCRIPTION
This PR addresses feedback from users who had the chat connection grey out without any indication that the websocket failed. It also addresses the issue that through dependabot updates automatically, it broke the mongo db vector search and caused a yet to be investigated issue with the kafka client and json serializer so was reverted (this is a hot fix for now).


**Backend Infrastructure**
- 📦 Dependency Revert: reverting kafka client and serialiser until further testing is done, dependabot automatically updated these.
- 📦 Dependency Update: Upgraded mongodb-driver-sync from 5.0.1 → 5.5.0 in pom.xml
- 🔧 Vector Search Migration: Updated MongoService.java to use new VectorSearchOptions.approximateVectorSearchOptions() API
- Replaced deprecated vector search parameters with modern options configuration
- Updated parameter types to long for compatibility

**Frontend User Experience**

- 🔄 Improved WebSocket Reconnection: Enhanced connection stability and user feedback
- Added isReconnecting state to differentiate between disconnected and reconnecting states
- Implemented smarter connection status display ("Reconnecting..." vs "Disconnected")
- Enhanced exponential backoff strategy (1s → 30s max interval)
- Improved heartbeat configuration (60s timeout/interval)

**💡 Better UX During Reconnection:**

- Users can now type messages during reconnection attempts
- Visual feedback with yellow status indicator during reconnection
- Prevents confusion between temporary connection loss and permanent disconnection


<img width="642" height="619" alt="Screenshot 2025-07-25 at 15 46 53" src="https://github.com/user-attachments/assets/ebefb4c8-6e47-43b6-ae89-5b1d3bb0c534" />
