### PR TITLE
feature(CI): Create initial Semaphore pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,7 +9,7 @@ execution_time_limit:
   hours: 1
 
 queue:
-  - when: "branch != 'master'"
+  - when: "branch != 'main'"
     processing: parallel
 
 blocks:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,71 @@
+# MongoDB Confluent GenAI Quickstart CI/CD Pipeline
+version: v1.0
+name: Build
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'master'"
+    processing: parallel
+
+blocks:
+  - name: "Frontend Build"
+    task:
+      env_vars:
+        - name: NODE_VERSION
+          value: "18"
+      prologue:
+        commands:
+          - checkout
+          - nvm use $NODE_VERSION
+          - cd frontend
+      jobs:
+        - name: "Build Frontend Application"
+          commands:
+            - echo "Installing frontend dependencies..."
+            - npm ci
+            - echo "Running type checking and building frontend..."
+            - npm run build
+            - echo "Frontend build completed successfully"
+
+  - name: "Java Backend Build"
+    task:
+      env_vars:
+        - name: JAVA_VERSION
+          value: "17"
+      prologue:
+        commands:
+          - checkout
+          - sem-version java $JAVA_VERSION
+          - cd infrastructure/modules/backend/search
+      jobs:
+        - name: "Build Java Search Service"
+          commands:
+            - echo "Building Java search service"
+            - mvn clean package -DskipTests
+            - echo "Java backend build completed successfully"
+
+  - name: "Infrastructure Validation"
+    task:
+      env_vars:
+        - name: TERRAFORM_VERSION
+          value: "1.5.7"
+      prologue:
+        commands:
+          - checkout
+          - sem-version terraform $TERRAFORM_VERSION
+          - cd infrastructure
+      jobs:
+        - name: "Validate Terraform Configuration"
+          commands:
+            - echo "Initializing Terraform..."
+            - terraform init -backend=false
+            - echo "Validating Terraform configuration..."
+            - terraform validate
+            - echo "Checking Terraform formatting..."
+            - terraform fmt -check -recursive
+            - echo "Infrastructure validation completed successfully"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,4 +1,3 @@
-# MongoDB Confluent GenAI Quickstart CI/CD Pipeline
 version: v1.0
 name: Build
 agent:

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,8 @@
+name: mongodb-cflt-genai-quickstart
+lang: unknown
+lang_version: unknown
+git:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_enable: false


### PR DESCRIPTION
Annoyingly can't test it until the `service.yml` file is in `main` so ServiceBot can create the project in Semaphore. I believe adding`semaphore.pipeline_enable: false` ensures ServiceBot doesn't try to manage the pipeline, but should still create the project (I hope.. 🤞).

This PR adds build/validation steps for:
- Frontend project
- Java search project
- Terraform infrastructure

May look at adding some linting for the Python backend also, but there's not a huge amount that can be done there without tests in place.